### PR TITLE
Typo Mistakes

### DIFF
--- a/tutorials/Tutorial1.md
+++ b/tutorials/Tutorial1.md
@@ -37,7 +37,7 @@ docker-compose up -d
 Install the hvbench-api:
 
 ```bash
-cd
+cd ..
 git clone https://github.com/csieber/hvbench-api
 cd hvbench-api
 sudo python3 setup.py install
@@ -65,7 +65,7 @@ docker ps
 Afterwards add a tenant to that instance using *add-tenant*. *add-tenant* will, by default, create a constant generator of type ECHO_REQUEST, add the tenant to instance 1 and will tell it to listen on the OpenFlow default port 6633.
 
 ```bash
-hvbench-ctrl add-tentant tutorial
+hvbench-ctrl add-tenant tutorial
 ```
 
 Now you should see a constant rate of ECHO_REQUEST messages in the *ovs-ofctl* output.


### PR DESCRIPTION
AT Line 68: typo mistake 'tentant' in command: correct one is : hvbench-ctrl add-tenant tutorial

AT line 40: changed to  cd .. from cd
